### PR TITLE
refactor: rename env var

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -52,7 +52,7 @@ on:
         type: boolean
 
     secrets:
-      RPC_URL_MAINNET:
+      MAINNET_RPC_URL:
         required: false
 
 jobs:
@@ -62,7 +62,7 @@ jobs:
       FOUNDRY_INVARIANT_RUNS: ${{ inputs.foundry-invariant-runs }}
       FOUNDRY_FUZZ_RUNS: ${{ inputs.foundry-fuzz-runs }}
       FOUNDRY_PROFILE: ${{ inputs.foundry-profile }}
-      RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
+      MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"


### PR DESCRIPTION
Closes https://github.com/sablier-labs/reusable-workflows/issues/9

Before we merge this, we need to add a secret org env variable `MAINNET_RPC_URL`