### PR TITLE
chore: remove `-vvv` flag

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -86,7 +86,7 @@ jobs:
           echo "FOUNDRY_FUZZ_SEED=$seed" >> $GITHUB_ENV
 
       - name: "Run the tests"
-        run: 'forge test --match-path "${{ inputs.match-path }}" -vvv'
+        run: 'forge test --match-path "${{ inputs.match-path }}"'
 
       - name: "Add summary"
         run: |


### PR DESCRIPTION
Removing `-vvv` flag as Github worflow UI is not able to display it due to its large size. Example, https://github.com/sablier-labs/flow/actions/runs/10989737602/job/30508576133