### PR TITLE
Build the contracts on default profile

### DIFF
--- a/.github/workflows/forge-build.yml
+++ b/.github/workflows/forge-build.yml
@@ -42,10 +42,7 @@ jobs:
         run: "forge config"
 
       - name: "Build the production contracts"
-        run: "FOUNDRY_PROFILE=optimized forge build"
-
-      - name: "Build the test contracts"
-        run: "FOUNDRY_PROFILE=test-optimized forge build"
+        run: "forge build"
 
       - name: "Cache the contracts and the node modules so that they can be re-used by the other jobs"
         if: ${{ inputs.save-cache }}

--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ This repository contains a collection of reusable GitHub Actions workflows.
 - [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 - [Sharing actions and workflows with your organization](https://docs.github.com/en/actions/creating-actions/sharing-actions-and-workflows-with-your-organization)
 - [How to start using reusable workflows with GitHub Actions](https://github.blog/2022-02-10-using-reusable-workflows-github-actions/)
+
+#### Repositories using these workflows
+
+Useful list, because if we make changes to this repo, we will most likely need to update these repos as well.
+
+- [airdrops](https://github.com/sablier-labs/airdrops/)
+- [flow](https://github.com/sablier-labs/flow/)
+- [lockup](https://github.com/sablier-labs/v2-core/)
+- [v2-periphery](https://github.com/sablier-labs/v2-periphery) (will be archived)


### PR DESCRIPTION
In order to make the simultaneously compilation, we need to update the `forge build` CI to compile on default. See [this](https://github.com/sablier-labs/flow/pull/342).

Closes #8 

