### PR TITLE
support `scripts/bash` path in prepare artifacts job

### DIFF
--- a/.github/workflows/forge-build.yml
+++ b/.github/workflows/forge-build.yml
@@ -71,7 +71,15 @@ jobs:
 
       - name: "Prepare the contract artifacts"
         if: ${{ inputs.store-artifacts }}
-        run: "./shell/prepare-artifacts.sh"
+        run: |
+          if [ -f "./shell/prepare-artifacts.sh" ]; then
+            "./shell/prepare-artifacts.sh"
+          elif [ -f "./scripts/bash/prepare-artifacts.sh" ]; then
+            "./scripts/bash/prepare-artifacts.sh"
+          else
+            echo "Error: Could not find prepare-artifacts.sh in either ./shell or ./scripts/bash directories"
+            exit 1
+          fi
 
       - name: "Store the contract artifacts in CI"
         if: ${{ inputs.store-artifacts }}

--- a/.github/workflows/forge-build.yml
+++ b/.github/workflows/forge-build.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: "boolean"
 
+      foundry-profiles:
+        default: |
+          optimized
+          test-optimized
+        required: false
+        type: "string"
+
 jobs:
   forge-build:
     runs-on: "ubuntu-latest"
@@ -52,11 +59,15 @@ jobs:
       - name: "Show the Forge config"
         run: "forge config"
 
-      - name: "Build the production contracts"
-        run: "FOUNDRY_PROFILE=optimized forge build"
-
-      - name: "Build the test contracts"
-        run: "FOUNDRY_PROFILE=test-optimized forge build"
+      - name: "Build contracts with specified profiles"
+        run: |
+          # Read profiles from the input and build for each one
+          echo "${{ inputs.foundry-profiles }}" | while read profile; do
+            if [ -n "$profile" ]; then
+              echo "Building with profile: $profile"
+              FOUNDRY_PROFILE=$profile forge build
+            fi
+          done
 
       - name: "Prepare the contract artifacts"
         if: ${{ inputs.store-artifacts }}


### PR DESCRIPTION
Closes #26 

Depends on #27 

I kept both versions as there are still branches where the CI is run and it would require executing it from the `shell` directory